### PR TITLE
fix bugs about normalizing after COLMAP process

### DIFF
--- a/colmap_runner/normalize_cam_dict.py
+++ b/colmap_runner/normalize_cam_dict.py
@@ -19,7 +19,7 @@ def get_tf_cams(cam_dict, target_radius=1.):
         return center.flatten(), diagonal
 
     center, diagonal = get_center_and_diag(cam_centers)
-    radius = diagonal / 2. * 1.1
+    radius = diagonal * 1.1
 
     translate = -center
     scale = target_radius / radius


### PR DESCRIPTION
I think probably there is a bug in normalizing process to pose matrix which is acquired by colmap.

```py
 def get_center_and_diag(cam_centers):
        cam_centers = np.hstack(cam_centers)
        avg_cam_center = np.mean(cam_centers, axis=1, keepdims=True)
        center = avg_cam_center
        dist = np.linalg.norm(cam_centers - center, axis=0, keepdims=True)
        diagonal = np.max(dist)
        return center.flatten(), diagonal

    center, diagonal = get_center_and_diag(cam_centers)
    radius = diagonal / 2. * 1.1

    translate = -center
    scale = target_radius / radius
```

In this code, diagonal is the distance from the center to the furthest camera. Therefore it's something like a radius of a sphere, and you want to normalize it to one. However, you divide diagonal by 2.0, so it seems that you use dialog as something like a diameter. In this case, if diameter = 1.4 for example, you get scale as 1.0 / (0.7*1.1) = 1.2987012987012987,  which is larger than 1.0. In fact, when I applied this script to my own dataset, I got an exception error message "not all your cameras are bounded by the unit sphere".

Thank you! 
